### PR TITLE
Fix the build to contain the dependency packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
 .tox
 *.egg-info
+dist
+build
 mermaid.js

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,10 +25,12 @@ classifiers =
 [options]
 packages =
     django_mermaid
+    django_mermaid.templatetags
 install_requires =
     urllib3
     Django
 include_package_data = yes
+python_requires = >=3.6
 package_dir =
     =src
 zip_safe = no


### PR DESCRIPTION
After the changes, `build` tree has the following structure.

```text
build/
├── bdist.linux-x86_64
└── lib
    └── django_mermaid
        ├── apps.py
        ├── __init__.py
        └── templatetags
            ├── __init__.py
            └── mermaid.py
```

`templatetags` **package is not missing anymore.**

Issue:
 - #6 